### PR TITLE
feat: gateway api

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         
       - name: next release version
         id: nextversion
-        uses: jenkins-x-plugins/jx-release-version@v2.6.11
+        uses: jenkins-x-plugins/jx-release-version@v2.9.6
         with:
           previous-version: from-file:charts/tekton-dashboard/Chart.yaml
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The following tools need to be installed locally:
 - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
 - [yq](https://github.com/mikefarah/yq/#install)
 
-### Jenkins X
+### JayeX
 
-If you are creating a template to be used in Jenkins X version, you can run the following command:
+If you are creating a template to be used in JayeX version, you can run the following command:
 
 ```bash
 make fetch

--- a/charts/tekton-dashboard/Chart.yaml
+++ b/charts/tekton-dashboard/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 description: A Helm chart for Tekton Pipelines Dashboard
 name: tekton-dashboard
-version: 0.1.3
-appVersion: "0.61.0"
+version: 0.1.4
+appVersion: "0.63.1"
 icon: https://avatars2.githubusercontent.com/u/47602533
 home: https://github.com/jenkins-x/tekton-dashboard-helm-chart
 dependencies:
   - name: oauth2-proxy
     repository: https://oauth2-proxy.github.io/manifests
-    version: 6.13.1
+    version: 10.6.0
     condition: oauth2-proxy.enabled

--- a/charts/tekton-dashboard/README.md
+++ b/charts/tekton-dashboard/README.md
@@ -1,7 +1,7 @@
 # tekton dashboard helm chart
 
 ## Setup
-First add the Jenkins X chart repository
+First add the JayeX chart repository
 
 ```sh
 helm repo add jxgh https://jenkins-x.github.io/tekton-dashboard-helm-chart/
@@ -15,3 +15,32 @@ helm repo update
 ```
 helm upgrade --install tekton-dashboard jxgh/tekton-dashboard-helm-chart
 ```
+
+## Exposure & authentication
+
+There are two independent exposure choices, plus the optional bundled
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) for authentication:
+
+1. **How the dashboard is exposed** — an `Ingress` (`ingress.enabled`) **or** the
+   Gateway API (`gateway.enabled`, which renders an `HTTPRoute` and, when
+   `gateway.auth.enabled`, an Envoy Gateway `SecurityPolicy`). `gateway.parentRefs`
+   defaults to the Envoy Gateway in `envoy-gateway-system`; override it for a custom
+   gateway.
+2. **How oauth2-proxy is exposed** (only when `oauth2-proxy.enabled`) — its own
+   `Ingress` (`oauth2-proxy.ingress.enabled`) **or** `HTTPRoute`
+   (`oauth2-proxy.gatewayApi.enabled`).
+
+The dashboard's auth mechanism follows how the **dashboard** is exposed:
+
+| Dashboard via | Auth mechanism | Configured by |
+|---|---|---|
+| Ingress | nginx `auth-url` / `auth-signin` annotations | `authHost` |
+| Gateway (`gateway.auth.type: extAuth`) | Envoy Gateway `SecurityPolicy` (`extAuth` → oauth2-proxy Service) | `gateway.auth.enabled` + `gateway.auth.extAuth.*` (requires Envoy Gateway) |
+| Gateway (`gateway.auth.type: oidc`) | Envoy Gateway `SecurityPolicy` (native `oidc`, no oauth2-proxy) | `gateway.auth.enabled` + `gateway.auth.oidc.*` (requires Envoy Gateway) |
+
+Auth is opt-in: with `gateway.enabled` alone, the dashboard is routed without auth.
+When `gateway.auth.enabled` is set, `type` defaults to `oidc` (Envoy Gateway handles OIDC flow; no oauth2-proxy required).
+
+Set `type: extAuth` to delegate auth to an external provider.
+
+It's recommended that the dashboard and auth provider share the same data plane (Ingress or Gateway API) to avoid complexity and potential issues with cookie domains, CORS, etc.

--- a/charts/tekton-dashboard/templates/dashboard-info-cm.yaml
+++ b/charts/tekton-dashboard/templates/dashboard-info-cm.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  version: v0.61.0
+  version: v0.63.1
 kind: ConfigMap
 metadata:
   labels:

--- a/charts/tekton-dashboard/templates/tekton-dashboard-deploy.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-deploy.yaml
@@ -7,9 +7,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: dashboard
     app.kubernetes.io/part-of: tekton-dashboard
-    app.kubernetes.io/version: v0.61.0
-    dashboard.tekton.dev/release: v0.61.0
-    version: v0.61.0
+    app.kubernetes.io/version: v0.63.1
+    dashboard.tekton.dev/release: v0.63.1
+    version: v0.63.1
   name: tekton-dashboard
 spec:
   replicas: 1
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: default
         app.kubernetes.io/name: dashboard
         app.kubernetes.io/part-of: tekton-dashboard
-        app.kubernetes.io/version: v0.61.0
+        app.kubernetes.io/version: v0.63.1
       name: tekton-dashboard
     spec:
       affinity:
@@ -60,7 +60,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/tektoncd/dashboard/dashboard-9623576a202fe86c8b7d1bc489905f86:v0.61.0@sha256:32c8bb482129b42c5b09a29b34140aed53dc3ade1d7e24fef7a194075d1c87c7
+        image: ghcr.io/tektoncd/dashboard/dashboard-9623576a202fe86c8b7d1bc489905f86:v0.63.1@sha256:16eca97b649f6f27dfbab2be167be0afc34bab43af9d3304f64bf7f04d44e606
         livenessProbe:
           httpGet:
             path: /health

--- a/charts/tekton-dashboard/templates/tekton-dashboard-httproute.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-httproute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tekton-dashboard
+  namespace: '{{ .Release.Namespace }}'
+  annotations:
+    {{- toYaml .Values.gateway.annotations | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.gateway.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  hostnames:
+    - {{ .Values.gateway.host }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: {{ .Values.gateway.pathPrefix }}
+    backendRefs:
+    - name: tekton-dashboard
+      port: 9097
+{{- end }}

--- a/charts/tekton-dashboard/templates/tekton-dashboard-ingress.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.host }}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/tekton-dashboard/templates/tekton-dashboard-securitypolicy.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-securitypolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.gateway.enabled .Values.gateway.auth.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: tekton-dashboard
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: tekton-dashboard
+  {{- if eq .Values.gateway.auth.type "extAuth" }}
+  extAuth:
+    failOpen: {{ .Values.gateway.auth.extAuth.failOpen }}
+    http:
+      backendRefs:
+      - name: {{ .Values.gateway.auth.extAuth.backend.serviceName | default "oauth2-proxy" }}
+        port: {{ .Values.gateway.auth.extAuth.backend.port | default 80 }}
+      path: {{ .Values.gateway.auth.extAuth.authPath }}
+      headersToBackend:
+        {{- toYaml .Values.gateway.auth.extAuth.headersToBackend | nindent 8 }}
+  {{- else if eq .Values.gateway.auth.type "oidc" }}
+  oidc:
+    provider:
+      issuer: {{ .Values.gateway.auth.oidc.issuer | quote }}
+      {{- with .Values.gateway.auth.oidc.authorizationEndpoint }}
+      authorizationEndpoint: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.gateway.auth.oidc.tokenEndpoint }}
+      tokenEndpoint: {{ . | quote }}
+      {{- end }}
+    {{- if .Values.gateway.auth.oidc.clientIDRef.name }}
+    clientIDRef:
+      name: {{ .Values.gateway.auth.oidc.clientIDRef.name | quote }}
+      {{- with .Values.gateway.auth.oidc.clientIDRef.kind }}
+      kind: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.gateway.auth.oidc.clientIDRef.namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
+    {{- else }}
+    clientID: {{ .Values.gateway.auth.oidc.clientID | quote }}
+    {{- end }}
+    clientSecret:
+      name: {{ .Values.gateway.auth.oidc.clientSecretRef.name | quote }}
+    {{- with .Values.gateway.auth.oidc.redirectURL }}
+    redirectURL: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.gateway.auth.oidc.logoutPath }}
+    logoutPath: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.gateway.auth.oidc.cookieDomain }}
+    cookieDomain: {{ . | quote }}
+    {{- end }}
+    scopes:
+      {{- toYaml .Values.gateway.auth.oidc.scopes | nindent 6 }}
+    forwardAccessToken: {{ .Values.gateway.auth.oidc.forwardAccessToken }}
+  {{- end }}
+{{- end }}

--- a/charts/tekton-dashboard/templates/tekton-dashboard-svc.yaml
+++ b/charts/tekton-dashboard/templates/tekton-dashboard-svc.yaml
@@ -7,9 +7,9 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/name: dashboard
     app.kubernetes.io/part-of: tekton-dashboard
-    app.kubernetes.io/version: v0.61.0
-    dashboard.tekton.dev/release: v0.61.0
-    version: v0.61.0
+    app.kubernetes.io/version: v0.63.1
+    dashboard.tekton.dev/release: v0.63.1
+    version: v0.63.1
   name: tekton-dashboard
 spec:
   ports:

--- a/charts/tekton-dashboard/values.yaml
+++ b/charts/tekton-dashboard/values.yaml
@@ -22,7 +22,7 @@ gateway:
   # External authentication
   # Rendered as an Envoy Gateway SecurityPolicy targeting the dashboard HTTPRoute
   auth:
-    enabled: false # Leave disabled when routing without auth
+    enabled: false
     # Which SecurityPolicy spec to render: oidc | extAuth
     type: oidc
     # oidc: OIDC connector to an identity provider via Envoy Gateway (eg. Okta, Keycloak, Dex, etc)

--- a/charts/tekton-dashboard/values.yaml
+++ b/charts/tekton-dashboard/values.yaml
@@ -1,9 +1,56 @@
+# Expose the dashboard via EITHER ingress OR gateway (Gateway API). See README for the
+# supported dashboard/oauth2-proxy exposure combinations.
 # tekton-ingress example with TLS enabled
 ingress:
+  enabled: true
   host: tekton-dashboard.acme.com
   tls:
     enabled: true
     secretName: example.com
+# Expose the dashboard via the Gateway API. When enabled this renders an HTTPRoute
+# and (when auth is enabled) an Envoy Gateway SecurityPolicy for the dashboard
+gateway:
+  enabled: false
+  host: tekton-dashboard.acme.com
+  pathPrefix: /
+  annotations: {}
+  # Gateways the HTTPRoute attaches to. Defaults to the Envoy Gateway
+  parentRefs:
+    - name: envoy-gateway
+      namespace: envoy-gateway-system
+      sectionName: https
+  # External authentication
+  # Rendered as an Envoy Gateway SecurityPolicy targeting the dashboard HTTPRoute
+  auth:
+    enabled: false # Leave disabled when routing without auth
+    # Which SecurityPolicy spec to render: oidc | extAuth
+    type: oidc
+    # oidc: OIDC connector to an identity provider via Envoy Gateway (eg. Okta, Keycloak, Dex, etc)
+    oidc:
+      issuer: ""
+      clientID: ""
+      # Alternatively, reference a Secret holding the client ID under key "client-id"
+      clientIDRef:
+        name: ""
+      # OIDC client secret under key "client-secret"
+      clientSecretRef:
+        name: ""
+      redirectURL: ""
+      logoutPath: /logout
+      scopes: []
+      cookieDomain: ""
+      # Optional explicit endpoints (otherwise discovered from the issuer)
+      authorizationEndpoint: ""
+      tokenEndpoint: ""
+      # Forward the access token upstream via Authorization: Bearer
+      forwardAccessToken: false
+    # extAuth: delegate to an external auth service
+    extAuth:
+      backend: {}
+      authPath: /oauth2/auth
+      failOpen: false
+      # headers the auth backend returns that are forwarded to the dashboard
+      headersToBackend: []
 # this is the auth host for the proxy (tekton-auth.example.com) and used to template ingress annotations for redirection
 # only add an authHost if deploying oauth2-proxy
 authHost:
@@ -24,6 +71,26 @@ oauth2-proxy:
     github-org: your-org
     cookie-domain: .example.com
     whitelist-domain: .example.com
+  # Expose sign-in and callback endpoints via Gateway API
+  gatewayApi:
+    enabled: false
+    # Gateway the oauth2-proxy HTTPRoute attaches to
+    gatewayRef: {}
+    # Route only the /oauth2 prefix to oauth2-proxy
+    # backendRef defaults oauth2-proxy Service
+    rules:
+      - matches:
+          - path:
+              type: PathPrefix
+              value: /oauth2
+    # Must match gateway.host so /oauth2/* lives alongside the dashboard.
+    hostnames:
+      - example.com
+    # Additional labels to add to the HTTPRoute
+    labels: {}
+    # Additional annotations to add to the HTTPRoute
+    annotations: {}
+  # Expose sign-in and callback endpoints via Ingress
   ingress:
     enabled: true
     path: /oauth2

--- a/src/templates/tekton-dashboard-httproute.yaml
+++ b/src/templates/tekton-dashboard-httproute.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: tekton-dashboard
+  namespace: '{{ .Release.Namespace }}'
+  annotations:
+    {{- toYaml .Values.gateway.annotations | nindent 4 }}
+spec:
+  parentRefs:
+    {{- range .Values.gateway.parentRefs }}
+    - name: {{ .name }}
+      {{- with .namespace }}
+      namespace: {{ . }}
+      {{- end }}
+      {{- with .sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+    {{- end }}
+  hostnames:
+    - {{ .Values.gateway.host }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: {{ .Values.gateway.pathPrefix }}
+    backendRefs:
+    - name: tekton-dashboard
+      port: 9097
+{{- end }}

--- a/src/templates/tekton-dashboard-ingress.yaml
+++ b/src/templates/tekton-dashboard-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.host }}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/src/templates/tekton-dashboard-securitypolicy.yaml
+++ b/src/templates/tekton-dashboard-securitypolicy.yaml
@@ -1,0 +1,59 @@
+{{- if and .Values.gateway.enabled .Values.gateway.auth.enabled }}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: tekton-dashboard
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: tekton-dashboard
+  {{- if eq .Values.gateway.auth.type "extAuth" }}
+  extAuth:
+    failOpen: {{ .Values.gateway.auth.extAuth.failOpen }}
+    http:
+      backendRefs:
+      - name: {{ .Values.gateway.auth.extAuth.backend.serviceName | default "oauth2-proxy" }}
+        port: {{ .Values.gateway.auth.extAuth.backend.port | default 80 }}
+      path: {{ .Values.gateway.auth.extAuth.authPath }}
+      headersToBackend:
+        {{- toYaml .Values.gateway.auth.extAuth.headersToBackend | nindent 8 }}
+  {{- else if eq .Values.gateway.auth.type "oidc" }}
+  oidc:
+    provider:
+      issuer: {{ .Values.gateway.auth.oidc.issuer | quote }}
+      {{- with .Values.gateway.auth.oidc.authorizationEndpoint }}
+      authorizationEndpoint: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.gateway.auth.oidc.tokenEndpoint }}
+      tokenEndpoint: {{ . | quote }}
+      {{- end }}
+    {{- if .Values.gateway.auth.oidc.clientIDRef.name }}
+    clientIDRef:
+      name: {{ .Values.gateway.auth.oidc.clientIDRef.name | quote }}
+      {{- with .Values.gateway.auth.oidc.clientIDRef.kind }}
+      kind: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.gateway.auth.oidc.clientIDRef.namespace }}
+      namespace: {{ . | quote }}
+      {{- end }}
+    {{- else }}
+    clientID: {{ .Values.gateway.auth.oidc.clientID | quote }}
+    {{- end }}
+    clientSecret:
+      name: {{ .Values.gateway.auth.oidc.clientSecretRef.name | quote }}
+    {{- with .Values.gateway.auth.oidc.redirectURL }}
+    redirectURL: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.gateway.auth.oidc.logoutPath }}
+    logoutPath: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.gateway.auth.oidc.cookieDomain }}
+    cookieDomain: {{ . | quote }}
+    {{- end }}
+    scopes:
+      {{- toYaml .Values.gateway.auth.oidc.scopes | nindent 6 }}
+    forwardAccessToken: {{ .Values.gateway.auth.oidc.forwardAccessToken }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
### Changes                                                                                                                                                                                                                                                                                            
* Create `HTTPRoute` and Envoy `SecurityPolicy` templates for Tekton Dashboard                                                                                                                                                                                                                         
* Add `ingress.enabled` boolean for enabling Tekton Dashboard `Ingress`                                                                                                                                                                                                                                
* Add default values for `oauth2-proxy.gatewayApi`                                                                                                                                                                                                                                                     
* Bump `oauth2-proxy` dependency `6.13.1` → `10.6.0`
* Document the supported exposure/auth combinations in the README

### Context
Add Gateway API support for the `tekton-dashboard` and the `oauth2-proxy` dependency.

Setting `gateway.enabled: true` creates a `HTTPRoute` for the dashboard without auth.

JayeX natively supports Envoy Gateway (https://github.com/jenkins-x/jx3-versions/pull/4376), so Envoy Gateway's `SecurityPolicy` is chosen as the auth provider here*.

Two Envoy Gateway auth mechanisms are supported via `gateway.auth.type`:
* `oidc` — Envoy Gateway drives the OIDC flow directly against the IdP (Okta, Keycloak, Dex, etc.); no oauth2-proxy required
* `extAuth` — delegates auth to an external provider

`ingress` is now gated on the explicit `ingress.enabled` flag rather than rendering whenever `ingress.host` was set, so `Ingress` and Gateway API are mutually exclusive.

Default values for `oauth2-proxy.gatewayApi` are added so oauth2-proxy can share the same data plane as the dashboard.

*Gateway API provides a `HTTPRoute` resource for traffic routing but treats authentication as a concern of the upstream Gateway provider. [This poses some issues for this chart, as there are various Gateway providers with their own auth implementations, which is out-of-scope of this chart.
